### PR TITLE
Redefinido controles de movimentacao

### DIFF
--- a/Instanciaveis/Scripts/Jogador.gd
+++ b/Instanciaveis/Scripts/Jogador.gd
@@ -42,16 +42,16 @@ func _process(delta: float) -> void:
 	# Everything works like you're used to in a top-down game
 	direcao = Vector2()
 
-	if Input.is_action_pressed("ui_up"):
+	if Input.is_action_pressed("andar_pra_cima"):
 		direcao += Vector2(0, -1)
 
-	elif Input.is_action_pressed("ui_down"):
+	elif Input.is_action_pressed("andar_pra_baixo"):
 		direcao += Vector2(0, 1)
 
-	if Input.is_action_pressed("ui_left"):
+	if Input.is_action_pressed("andar_pra_esquerda"):
 		direcao += Vector2(-1, 0)
 
-	elif Input.is_action_pressed("ui_right"):
+	elif Input.is_action_pressed("andar_pra_direita"):
 		direcao += Vector2(1, 0)
 
 	movimento = direcao.normalized() * velocidade

--- a/project.godot
+++ b/project.godot
@@ -72,6 +72,26 @@ ataque_purificacao={
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":2,"pressed":false,"doubleclick":false,"script":null)
  ]
 }
+andar_pra_cima={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+ ]
+}
+andar_pra_direita={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+ ]
+}
+andar_pra_esquerda={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+ ]
+}
+andar_pra_baixo={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 


### PR DESCRIPTION
Ao inves de usar as setas para controlar seu personagem, agora se usa WASD. Isso foi feito pois o mouse é usado, e o jogador iria ficar numa posicao desconfortavel se usasse as setas com a mao esquerda e o mouse com a mao direita