### PR TITLE
Rebalanceamento e adicionado delay para começar a descarregar a purificação

### DIFF
--- a/Instanciaveis/Jogador.tscn
+++ b/Instanciaveis/Jogador.tscn
@@ -154,6 +154,8 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_group_": true
 }
+tempo_carregar_ataque_purificacao = 0.5
+dano_ofensivo = 2.5
 cena_projetil_purificacao = ExtResource( 5 )
 velocidade = 3000.0
 

--- a/Instanciaveis/JogadorBarata.tscn
+++ b/Instanciaveis/JogadorBarata.tscn
@@ -70,7 +70,7 @@ animations = [ {
 } ]
 
 [node name="Jogador" instance=ExtResource( 2 )]
-tempo_carregar_ataque_purificacao = 0.5
+tempo_carregar_ataque_purificacao = 0.25
 dano_ofensivo = 0.5
 dano_purificacao = 2.0
 velocidade = 4500.0

--- a/Instanciaveis/JogadorTigre.tscn
+++ b/Instanciaveis/JogadorTigre.tscn
@@ -77,7 +77,8 @@ animations = [ {
 } ]
 
 [node name="Jogador" instance=ExtResource( 1 )]
-dano_ofensivo = 2.5
+tempo_carregar_ataque_purificacao = 1.0
+dano_ofensivo = 4.0
 velocidade = 2100.0
 vida_max = 20.0
 desaceleracao_empurrao = 6.0


### PR DESCRIPTION
* Aumentado dano ofensivo dos Personagnes Monge e Tigre
* Diminuído tempo de carregamento do ataque de purificação do Monge e da JogadorBarata
* Quando o ataque de purificação tiver carregado, ele só começará a descarregar após o jogador se movimentar por um certo tempo, ao invés de começar a descarregar instantaneamente